### PR TITLE
[IMP] mrp_multi_level_turnover_report module: Hide header information…

### DIFF
--- a/mrp_multi_level_turnover_report/__manifest__.py
+++ b/mrp_multi_level_turnover_report/__manifest__.py
@@ -44,4 +44,9 @@
         "views/report_view.xml",
         "security/ir.model.access.csv",
     ],
+    "assets": {
+        "web.assets_backend": [
+            "mrp_multi_level_turnover_report/static/src/scss/style.scss",
+        ],
+    },
 }

--- a/mrp_multi_level_turnover_report/static/src/scss/style.scss
+++ b/mrp_multi_level_turnover_report/static/src/scss/style.scss
@@ -1,0 +1,12 @@
+.o_pivot table {
+    th[data-tooltip="Total Inventory Turnover"],
+    th[data-tooltip="Total Coverage in Days"],
+    th[data-tooltip="Temp Value"],
+    th[data-tooltip="Temp Float"] {
+        visibility: hidden;
+        padding: 0px;
+        overflow: hidden;
+        font-size: 0px;
+        background-color: white;
+    }
+}


### PR DESCRIPTION
… from grouped elements.

This information is already shown, but then again it is needed in calculations. I checked that calculations show correct results after these changes. Note that "display: none" does not work here, because it would mess up the calculations.